### PR TITLE
add: capability of selecting warehouse on load

### DIFF
--- a/macros/plugins/snowflake/snowpipe/create_empty_table.sql
+++ b/macros/plugins/snowflake/snowpipe/create_empty_table.sql
@@ -1,6 +1,21 @@
 {% macro snowflake_create_empty_table(source_node) %}
 
     {%- set columns = source_node.columns.values() %}
+    {%- set external = source_node.external %}
+    {%- set warehouse = external.snowflake_warehouse -%}
+
+    {% if not warehouse %}
+        {% set warehouse = target.warehouse %}
+    {% endif %}
+
+    {% set query_set_warehouse %}
+        use warehouse {{ warehouse }}
+    {% endset %}
+    {% if execute %}
+        {% set result_chnage_warehouse = run_query(query_set_warehouse) %}
+    {% endif %}
+    
+
 
     create or replace table {{source(source_node.source_name, source_node.name)}} (
         {% if columns|length == 0 %}


### PR DESCRIPTION
Adds option to change in the YAML config the warehouse to use for the loading process using `snowflake_warehouse` key. If it is empty the default warehouse specified on target will be used. (Only works when snowpipe is present).

```yaml
 tables:
    - name: copy_2XL_base
       external:
        snowflake_warehouse: GOOGLE_AD_DATA_TRANSFORMER_WH
```