### PR TITLE
fix: change explicit transaction to false

### DIFF
--- a/macros/plugins/snowflake/get_external_build_plan.sql
+++ b/macros/plugins/snowflake/get_external_build_plan.sql
@@ -16,7 +16,7 @@
             {% set build_plan = build_plan + [
                 dbt_external_tables.create_external_schema(source_node),
                 dbt_external_tables.snowflake_create_empty_table(source_node),
-                dbt_external_tables.snowflake_get_copy_sql(source_node, explicit_transaction=true),
+                dbt_external_tables.snowflake_get_copy_sql(source_node, explicit_transaction=false),
                 dbt_external_tables.snowflake_create_snowpipe(source_node)
             ] %}
         {% else %}


### PR DESCRIPTION
Changes explicit transaction to false, so commit and begin are not used and a change of snowflake session does not prevent the copy statement to be completed