### PR TITLE
fix: remove nullif from copy statement

### DIFF
--- a/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
+++ b/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
@@ -16,8 +16,8 @@
         {% else -%}
         {%- for column in columns -%}
             {%- set col_expression -%}
-                {%- if is_csv -%}nullif(${{loop.index}},''){# special case: get columns by ordinal position #}
-                {%- else -%}nullif($1:{{column.name}},''){# standard behavior: get columns by name #}
+                {%- if is_csv -%}${{loop.index}}{# special case: get columns by ordinal position #}
+                {%- else -%}$1:{{column.name}}{# standard behavior: get columns by name #}
                 {%- endif -%}
             {%- endset -%}
             {{col_expression}}::{{column.data_type}} as {{column.name}},


### PR DESCRIPTION
Remove unnecessary nullif statements for all files on copy into command to speed up the loading process (speed up of 50-100%)
