### PR TITLE
add: wildcard selection

### DIFF
--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -13,7 +13,12 @@
                 
                     {% if '.' in src %}
                         {% set src_s = src.split('.') %}
-                        {% if src_s[0] == node.source_name and src_s[1] == node.name %}
+                        {% if src_s[0] == node.source_name and 
+                            (
+                                src_s[1] == node.name or 
+                                ('*' in src_s[1] and src_s[1]|replace('*', '') in node.name)
+                            )
+                        %}
                             {% do sources_to_stage.append(node) %}
                         {% endif %}
                     {% else %}


### PR DESCRIPTION
Adds possibility to choose external tables using wildcard. 

**Note:** It will match any table that has the same name provided as substring, regardless of where the wildcard is introduced.

Ex:
source_name.my_external_* 

or 

source_name.*my_external_ 

will match:
source_name.my_external_1
source_name.my_external_useful
source_name.this_is_my_external_table

it won't match:

another_source_name.my_external_1
another_source_name.this_is_my_external_table